### PR TITLE
Use apkup instead of playup

### DIFF
--- a/apkup
+++ b/apkup
@@ -1,6 +1,7 @@
+#!/usr/bin/env bash
 make -B amiko
 make -B comed
 scp build/outputs/apk/amiko/release/AmiKo-Android-amiko-release.apk zeno@192.168.0.166:/home/ftp/
 scp build/outputs/apk/comed/release/AmiKo-Android-comed-release.apk zeno@192.168.0.166:/home/ftp/
-#playup -a amiko.json ~/.software/AmiKo-Android/build/outputs/apk/amiko/release/AmiKo-Android-amiko-release.apk
-#playup -a amiko.json ~/.software/AmiKo-Android/build/outputs/apk/comed/release/AmiKo-Android-comed-release.apk
+apkup --key amiko.json --apk ./build/outputs/apk/amiko/release/AmiKo-Android-amiko-release-unsigned.apk
+apkup --key amiko.json --apk ./build/outputs/apk/comed/release/AmiKo-Android-comed-release.apk


### PR DESCRIPTION
Fix #109 

- You should install `apkup` first.
   ```
    npm install -g apkup
    ```
- Instead of `./playup`, you should do `./apkup` now.
- I followed the manual to migrate from playup to apkup, but I do not have the credential to test if it works.